### PR TITLE
Add auto-scrolling to the panel when tests are running

### DIFF
--- a/lib/ruby-test-view.coffee
+++ b/lib/ruby-test-view.coffee
@@ -90,3 +90,4 @@ class RubyTestView extends View
 
   flush: ->
     @results.text(@output)
+    @results.parent().scrollTop(@results.innerHeight())


### PR DESCRIPTION
Hi @moxley, me again.

I thought it would be helpful if the test panel would autoscroll to the bottom while the tests are running.

I find that it's most important for me to see the results of the tests once these have finished.

What do you think?

Thanks in advance!
