### PR TITLE
Platform specific key bindings for Mac and Linux

### DIFF
--- a/keymaps/ruby-test.cson
+++ b/keymaps/ruby-test.cson
@@ -7,10 +7,18 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.platform-darwin .workspace':
   'cmd-ctrl-x': 'ruby-test:toggle'
   'cmd-ctrl-y': 'ruby-test:test-all'
   'cmd-ctrl-t': 'ruby-test:test-file'
   'cmd-ctrl-r': 'ruby-test:test-single'
   'cmd-ctrl-e': 'ruby-test:test-previous'
   'cmd-ctrl-c': 'ruby-test:cancel'
+  
+'.platform-linux .workspace':
+  'ctrl-shift-c': 'ruby-test:cancel'
+  'ctrl-shift-e': 'ruby-test:test-previous'
+  'ctrl-shift-r': 'ruby-test:test-single'
+  'ctrl-shift-t': 'ruby-test:test-file'
+  'ctrl-shift-x': 'ruby-test:toggle'
+  'ctrl-shift-y': 'ruby-test:test-all'


### PR DESCRIPTION
I'm using your package in Linux where there is no Cmd key, so I changed it to Ctrl for .platform-linux.
Bindings are the same as in ST.
