### PR TITLE
Passing tests

### DIFF
--- a/spec/source-info-spec.coffee
+++ b/spec/source-info-spec.coffee
@@ -53,7 +53,7 @@ describe "SourceInfo", ->
 
   describe "::currentShell", ->
     it "when ruby-test.shell is null", ->
-      expect(@params.currentShell).toBe('bash')
+      expect(@params.currentShell()).toBe('bash')
 
   afterEach ->
     delete atom.project


### PR DESCRIPTION
Was getting a test failure locally. This should resolve it! Thanks for an awesome package!

```
.............F..

SourceInfo
  ::currentShell
    it when ruby-test.shell is null
      Expected Function to be 'bash'. (spec/source-info-spec.coffee:56:36)
```