### PR TITLE
Fix atom engine semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "https://github.com/moxley/atom-ruby-test",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.174.0, <2.0.0"
+    "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
     "underscore-plus": "^1.0.6",


### PR DESCRIPTION
This was a typo in Atom's docs for upgrading packages. The current semver `>=0.174.0, <2.0.0` is not valid and is skipped when installing via apm. See https://github.com/atom/atom/pull/5417 for more details. You'll need to publish a new version of the package after merging this.
