### PR TITLE
Use @cwd() instead of atom.project.path.

### DIFF
--- a/lib/ruby-test-view.coffee
+++ b/lib/ruby-test-view.coffee
@@ -13,6 +13,8 @@ class RubyTestView extends View
       @div class: "panel-heading", =>
         @span 'Running tests: '
         @span outlet: 'header'
+        @div class: "heading-buttons pull-right inline-block", =>
+          @div click: 'closePanel', class: "heading-close icon-x inline-block"
       @div class: "panel-body", =>
         @div class: 'ruby-test-spinner', 'Starting...'
         @pre "", outlet: 'results'
@@ -33,6 +35,10 @@ class RubyTestView extends View
   destroy: ->
     @output = ''
     @detach()
+
+  closePanel: ->
+    if @hasParent()
+      @detach()
 
   toggle: ->
     if @hasParent()

--- a/lib/source-info.coffee
+++ b/lib/source-info.coffee
@@ -52,11 +52,11 @@ module.exports =
           matches[1]
 
     projectType: ->
-      if fs.existsSync(atom.project.path + '/test')
+      if fs.existsSync(@cwd() + '/test')
         'test'
-      else if fs.existsSync(atom.project.path + '/spec')
+      else if fs.existsSync(@cwd() + '/spec')
         'rspec'
-      else if fs.existsSync(atom.project.path + '/feature')
+      else if fs.existsSync(@cwd() + '/feature')
         'cucumber'
       else
         null

--- a/spec/source-info-spec.coffee
+++ b/spec/source-info-spec.coffee
@@ -13,7 +13,6 @@ describe "SourceInfo", ->
         ["fooPath"]
       relativize: (filePath) ->
         "fooDirectory/#{filePath}"
-      path: "project/path"
 
 
   setUpPackageConfig = ->
@@ -52,6 +51,28 @@ describe "SourceInfo", ->
     it "is atom.project.getPaths()[0]", ->
       setUpWithoutOpenFile()
       expect(sourceInfo.cwd()).toBe("fooPath")
+
+  describe "::projectType", ->
+    it "correctly detects a test directory", ->
+      spyOn(fs, 'existsSync').andCallFake (filePath) ->
+        filePath.match(/fooPath\/test$/)
+
+      setUpWithoutOpenFile()
+      expect(sourceInfo.projectType()).toBe("test")
+
+    it "correctly detecs a spec directory", ->
+      spyOn(fs, 'existsSync').andCallFake (filePath) ->
+        filePath.match(/fooPath\/spec$/)
+
+      setUpWithoutOpenFile()
+      expect(sourceInfo.projectType()).toBe("rspec")
+
+    it "correctly detects a cucumber directory", ->
+      spyOn(fs, 'existsSync').andCallFake (filePath) ->
+        filePath.match(/fooPath\/feature$/)
+
+      setUpWithoutOpenFile()
+      expect(sourceInfo.projectType()).toBe("cucumber")
 
   describe "::testAllCommand", ->
     it "is the atom config for 'ruby-test.testAllCommand'", ->

--- a/styles/ruby-test.less
+++ b/styles/ruby-test.less
@@ -37,3 +37,7 @@
   padding-top: 70px;
   text-align: center;
 }
+
+.ruby-test .heading-close {
+  cursor: pointer;
+}


### PR DESCRIPTION
* @cwd() already gets the root project path, use that instead.
* This allows tests to the `test all` command to be run from any file in
the project or from no file at all, which is much better expected
behavior.

Fixes #44