### PR TITLE
Allow using {test} in test runner command lines

### DIFF
--- a/lib/source-info.coffee
+++ b/lib/source-info.coffee
@@ -37,6 +37,24 @@ module.exports =
         else
           null
 
+    currentTest: ->
+      @_currentTest ||= unless @_currentTest
+        editor = atom.workspace.getActiveTextEditor()
+        cursor = editor and editor.getCursor()
+        if cursor
+          result = null
+          for row in [cursor.getBufferRow()..0]
+            line = editor.lineForBufferRow(row)
+            if matches = line.match(/test ["'](.*)["']/)
+              result = "test_" + matches[1].replace(/\ /g, "_")
+              break
+            else if matches = line.match(/def (test_.*)/)
+              result = matches[1]
+              break
+          result
+        else
+          null
+
     testFramework: ->
       @_testFramework ||= unless @_testFramework
         (t = @fileType()) and @frameworkLookup[t] or

--- a/lib/test-runner.coffee
+++ b/lib/test-runner.coffee
@@ -30,7 +30,8 @@ module.exports =
         else
           @testParams.testFileCommand()
       cmd.replace('{relative_path}', @testParams.activeFile()).
-          replace('{line_number}', @testParams.currentLine())
+          replace('{line_number}', @testParams.currentLine()).
+          replace('{test}', @testParams.currentTest())
 
     cancel: ->
       @shell.kill()


### PR DESCRIPTION
Since minitest doesn't support running the test on a specified line, I think it'd be nice to support a `{test}` variable expanding to the name of the current test, so that minitest users can run something like `ruby -I test {relative_path} -n {test}` for their `ruby-test:test-single` command.

Not 100% sure how to go about converting `test "bla bla bla" do` to a test function name the same way minitest does, but this implementation contains a feeble attempt.