### PR TITLE
Close Test panel on escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Open the test file you want to run, then issue one of the following:
 * `cmd-ctrl-r` - Run the test at the current line in test file
 * `cmd-ctrl-e` - Re-run the previous test (doesn't need to have the test file active)
 * `cmd-ctrl-x` - Show/hide the test panel
+* `escape` - Hide the test panel
 
 ## Features
 

--- a/keymaps/ruby-test.cson
+++ b/keymaps/ruby-test.cson
@@ -8,6 +8,7 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.platform-darwin atom-workspace':
+  'escape': 'ruby-test:close'
   'cmd-ctrl-x': 'ruby-test:toggle'
   'cmd-ctrl-y': 'ruby-test:test-all'
   'cmd-ctrl-t': 'ruby-test:test-file'
@@ -20,5 +21,6 @@
   'ctrl-shift-e': 'ruby-test:test-previous'
   'ctrl-shift-r': 'ruby-test:test-single'
   'ctrl-shift-t': 'ruby-test:test-file'
+  'escape': 'ruby-test:close'
   'ctrl-shift-x': 'ruby-test:toggle'
   'ctrl-shift-y': 'ruby-test:test-all'

--- a/lib/ruby-test-view.coffee
+++ b/lib/ruby-test-view.coffee
@@ -21,6 +21,7 @@ class RubyTestView extends View
 
   initialize: (serializeState) ->
     atom.commands.add "atom-workspace", "ruby-test:toggle", => @toggle()
+    atom.commands.add "atom-workspace", "ruby-test:close", => @closePanel()
     atom.commands.add "atom-workspace", "ruby-test:test-file", => @testFile()
     atom.commands.add "atom-workspace", "ruby-test:test-single", => @testSingle()
     atom.commands.add "atom-workspace", "ruby-test:test-previous", => @testPrevious()

--- a/spec/ruby-test-spec.coffee
+++ b/spec/ruby-test-spec.coffee
@@ -28,3 +28,18 @@ describe "RubyTest", ->
         expect(workspaceElement.querySelector('.ruby-test')).toExist()
         atom.commands.dispatch workspaceElement, 'ruby-test:toggle'
         expect(workspaceElement.querySelector('.ruby-test')).not.toExist()
+
+  describe "when the ruby-test:close event is triggered", ->
+    it "detaches the view", ->
+      expect(workspaceElement.querySelector('.ruby-test')).not.toExist()
+
+      # This is an activation event, triggering it will cause the package to be
+      # activated.
+      atom.commands.dispatch workspaceElement, 'ruby-test:toggle'
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        atom.commands.dispatch workspaceElement, 'ruby-test:close'
+        expect(workspaceElement.querySelector('.ruby-test')).not.toExist()


### PR DESCRIPTION
Enables the Escape key to close the Test Panel. The idea is to enable to quickly close the panel when the tests pass and you want to continue coding with a single key stroke.