### PR TITLE
Enable copying text from output pane

### DIFF
--- a/lib/ruby-test-view.coffee
+++ b/lib/ruby-test-view.coffee
@@ -8,7 +8,7 @@ Convert = require 'ansi-to-html'
 module.exports =
 class RubyTestView extends View
   @content: ->
-    @div class: "ruby-test inset-panel panel-bottom", =>
+    @div class: "ruby-test inset-panel panel-bottom native-key-bindings", tabindex: -1, =>
       @div class: "ruby-test-resize-handle"
       @div class: "panel-heading", =>
         @span 'Running tests: '


### PR DESCRIPTION
@moxley - here's a simple tweak which addresses https://github.com/moxley/atom-ruby-test/issues/6.