### PR TITLE
testScope should be specified for testFile().

### DIFF
--- a/lib/ruby-test-view.coffee
+++ b/lib/ruby-test-view.coffee
@@ -50,7 +50,7 @@ class RubyTestView extends View
         @setTestInfo("No tests running")
 
   testFile: ->
-    @runTest()
+    @runTest(testScope: "file")
 
   testSingle: ->
     @runTest(testScope: "single")


### PR DESCRIPTION
Otherwise, "Unknown scope" error occurs when ruby-test:test-file is invoked.
