### PR TITLE
Add information about cancelling a test run to the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://api.travis-ci.org/moxley/atom-ruby-test.svg?branch=master)](https://travis-ci.org/moxley/atom-ruby-test)
 
-Run Ruby tests, Rspec examples, and Cucumber features from Atom,
+Run Ruby tests, RSpec examples, and Cucumber features from Atom,
 quickly and easily.
 
 ![Running tests is quick and easy](http://cl.ly/image/300n2g101z0y/ruby-test6.gif)
@@ -30,6 +30,7 @@ Open the test file you want to run, then issue one of the following:
 * `cmd-ctrl-r` - Run the test at the current line in test file
 * `cmd-ctrl-e` - Re-run the previous test (doesn't need to have the test file active)
 * `cmd-ctrl-x` - Show/hide the test panel
+* `cmd-ctrl-c` - Cancel current test run
 
 ## Features
 
@@ -40,7 +41,7 @@ Open the test file you want to run, then issue one of the following:
 * Configure the shell commands that run the tests
 * Supports Ruby managers, like `rvm` and `rbenv`
 * Supports bash, z-shell, fish
-* Supports Test::Unit, Rspec, Minitest, and Cucumber
+* Supports Test::Unit, RSpec, Minitest, and Cucumber
 
 ## Helpful Tips
 


### PR DESCRIPTION
I was looking through the documentation for how to cancel the current test run, but found that the information was missing from the `README`. This change adds it in.

It also changes to the proper title capitalization of RSpec in two places. 😀 