### PR TITLE
Update ruby-test.coffee

### DIFF
--- a/lib/ruby-test.coffee
+++ b/lib/ruby-test.coffee
@@ -13,7 +13,7 @@ module.exports =
     minitestSingleCommand:
       title: "Minitest command: Run current test"
       type: 'string'
-      default: "ruby {relative_path} -n \"/{regex}/\""
+      default: "ruby -I test {relative_path} -n \"/{regex}/\""
     testAllCommand:
       title: "Ruby Test command: Run all tests"
       type: 'string'


### PR DESCRIPTION
Include `test` folder by default in `minitestSingleCommand`, consistent with the other commands.