### PR TITLE
Fallback to selected path from tree view if no active editor

### DIFF
--- a/lib/source-info.coffee
+++ b/lib/source-info.coffee
@@ -148,4 +148,4 @@ module.exports =
 
     filePath: ->
       util = new Utility
-      util.filePath()
+      util.activePath()

--- a/lib/utility.coffee
+++ b/lib/utility.coffee
@@ -3,11 +3,20 @@ class Utility
   saveFile: ->
     @editor().save() if @filePath()
 
+  activePath: ->
+    @filePath() or @treeViewSelectedPath()
+
   filePath: ->
     @editor() and
       @editor().buffer and
       @editor().buffer.file and
       @editor().buffer.file.path
 
+  treeViewSelectedPath: ->
+    @treeView().mainModule.treeView.selectedPath if @treeView()
+
   editor: ->
     atom.workspace.getActiveTextEditor()
+
+  treeView: ->
+    atom.packages.getActivePackage('tree-view')

--- a/spec/source-info-spec.coffee
+++ b/spec/source-info-spec.coffee
@@ -26,6 +26,11 @@ describe "SourceInfo", ->
     if 'testFile' of opts
       editor.buffer.file.path = opts.testFile
 
+    if 'testTreeviewPath' of opts
+      delete editor.buffer.file.path
+      treeViewPackage = { mainModule: { treeView: { selectedPath: opts.testTreeviewPath }} }
+      spyOn(atom.packages, 'getActivePackage').andReturn(treeViewPackage)
+
     if 'projectPaths' of opts
       atom.project.getPaths = -> opts.projectPaths
 
@@ -241,6 +246,13 @@ describe "SourceInfo", ->
         projectPaths: ['/projects/project_1', '/projects/project_2']
         testFile: '/projects/project_2/bar/foo_test.rb'
       expect(sourceInfo.activeFile()).toBe("bar/foo_test.rb")
+
+    it "if no active editor, it is the selected path in treeview", ->
+      withSetup
+        projectPaths: ['/projects/project_1', '/projects/project_2']
+        testTreeviewPath: '/projects/project_2/foo/bar'
+      expect(sourceInfo.activeFile()).toBe("foo/bar")
+
 
   describe "::currentLine", ->
     it "is the cursor getBufferRow() plus 1", ->


### PR DESCRIPTION
### Why

At the moment when there is no active editor, the `test-file` command fires off an `rspec undefined` test command.

### What

I thought it would be nice to fall back to the selected path (file or folder) from the tree view when there is no active editor.
