### PR TITLE
Reuse an existing terminal instead of creating a new one each time

### DIFF
--- a/lib/test-runner.coffee
+++ b/lib/test-runner.coffee
@@ -18,15 +18,15 @@ module.exports =
         alert("Platformio IDE Terminal package is disabled. It must be enabled to run tests.")
         return
 
-      if (@terminal.lastTerminalForTest)
-        # if we have a previous terminal opened from this test runner, close it
-        @terminal.lastTerminalForTest.closeBtn.click()
-
       @returnFocusToEditorAfterTerminalRun();
-
-      @terminal.run([@command()])
-      terminals =  @terminal.getTerminalViews()
-      @terminal.lastTerminalForTest = terminals[terminals.length - 1]
+      terminals = @terminal.getTerminalViews()
+      if (@terminal.lastTerminalForTestIdx != null && terminals[@terminal.lastTerminalForTestIdx])
+        lastTerminalForTest = terminals[@terminal.lastTerminalForTestIdx]
+        lastTerminalForTest.open()
+        lastTerminalForTest.input(@command() + "\n")
+      else
+        @terminal.run([@command()])
+        @terminal.lastTerminalForTestIdx = @terminal.getTerminalViews().length - 1
 
     returnFocusToEditorAfterTerminalRun: =>
       editor = @utility.editor()

--- a/spec/test-runner-spec.coffee
+++ b/spec/test-runner-spec.coffee
@@ -6,8 +6,9 @@ describe "TestRunner", ->
 
   beforeEach ->
     @mockRun = jasmine.createSpy('run')
-    @mockClick = jasmine.createSpy('click')
-    @mockGetTerminalViews = [ { closeBtn: { click: @mockClick } } ]
+    @mockTerminalInput = jasmine.createSpy('input')
+    @mockOpen = jasmine.createSpy('open')
+    @mockGetTerminalViews = [ { input: @mockTerminalInput, open: @mockOpen } ]
     @mockTerminal = {
       run: @mockRun, getTerminalViews: => @mockGetTerminalViews
     }
@@ -25,7 +26,8 @@ describe "TestRunner", ->
       runner = new TestRunner(@testRunnerParams, @mockTerminal)
       runner.run()
       expect(@mockRun).toHaveBeenCalledWith(["fooTestCommand fooTestFile:100"])
-      expect(@mockClick).not.toHaveBeenCalled()
+      expect(@mockOpen).not.toHaveBeenCalled()
+      expect(@mockTerminalInput).not.toHaveBeenCalled()
 
     it "constructs a single-minitest command when testScope is 'single'", ->
       Command.testSingleCommand.andReturn('fooTestCommand {relative_path} -n \"/{regex}/\"')
@@ -34,10 +36,11 @@ describe "TestRunner", ->
       runner.run()
       expect(@mockRun).toHaveBeenCalledWith(["fooTestCommand fooTestFile -n \"/test foo/\""])
 
-    it "closes the previous terminal used for testing", ->
+    it "reuses the previous terminal used for testing", ->
       @testRunnerParams.testScope = "single"
       runner = new TestRunner(@testRunnerParams, @mockTerminal)
       runner.run()
       runner = new TestRunner(@testRunnerParams, @mockTerminal)
       runner.run()
-      expect(@mockClick).toHaveBeenCalled()
+      expect(@mockOpen).toHaveBeenCalled()
+      expect(@mockTerminalInput).toHaveBeenCalledWith("fooTestCommand fooTestFile:100\n")


### PR DESCRIPTION
Fixes https://github.com/moxley/atom-ruby-test/issues/107