### PR TITLE
Use the terminus package to run commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Master
+
+* Use the terminus package to run commands
+
 ## Version 1.0.2
 
 * #101 Add ruby include path default test command

--- a/lib/ruby-test-view.coffee
+++ b/lib/ruby-test-view.coffee
@@ -35,7 +35,7 @@ class RubyTestView extends View
     atom.views.getView(atom.workspace.getActiveTextEditor())
 
   toggle: ->
-    atom.commands.dispatch(@currentEditor(), 'platformio-ide-terminal:toggle')
+    atom.commands.dispatch(@currentEditor(), 'terminus:toggle')
 
   testFile: ->
     @runTest(testScope: "file")
@@ -65,7 +65,7 @@ class RubyTestView extends View
       @spinner = @find('.ruby-test-spinner')
 
   cancelTest: ->
-    atom.commands.dispatch(@currentEditor(), 'platformio-ide-terminal:close')
+    atom.commands.dispatch(@currentEditor(), 'terminus:close')
 
   saveFile: ->
     util = new Utility

--- a/lib/test-runner.coffee
+++ b/lib/test-runner.coffee
@@ -14,8 +14,8 @@ module.exports =
       @utility = new Utility
 
     run: ->
-      if atom.packages.isPackageDisabled('platformio-ide-terminal')
-        alert("Platformio IDE Terminal package is disabled. It must be enabled to run tests.")
+      if atom.packages.isPackageDisabled('terminus')
+        alert("Terminus package is disabled. It must be enabled to run tests.")
         return
 
       @returnFocusToEditorAfterTerminalRun();
@@ -44,7 +44,7 @@ module.exports =
         editor.setCursorBufferPosition(cursorPos, {autoscroll: true})
         panels = atom.workspace.getBottomPanels();
         for panel in panels
-          if panel.getItem().hasClass?('platformio-ide-terminal')
+          if panel.getItem().hasClass?('terminus')
             panel.getItem().blur()
 
         editor.getElement().focus()

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "atom-package-deps": "^4.3"
   },
   "package-deps": [
-    "platformio-ide-terminal"
+    "terminus"
   ],
   "keywords": [
     "ruby",
@@ -36,9 +36,9 @@
     "cucumber"
   ],
   "consumedServices": {
-    "runInTerminal": {
+    "terminusTerminal": {
       "versions": {
-        "0.14.x": "consumeRunInTerminal"
+        "1.1.x": "consumeRunInTerminal"
       }
     }
   }

--- a/spec/ruby-test-spec.coffee
+++ b/spec/ruby-test-spec.coffee
@@ -15,7 +15,7 @@ describe "RubyTest", ->
     activationPromise = atom.packages.activatePackage('ruby-test')
 
   describe "when the ruby-test:test-file event is triggered", ->
-    it "displays the platformio-ide-terminal", ->
+    it "displays terminus", ->
       spyOn(RubyTestView.prototype, 'initialize').andReturn({ destroy: -> })
 
       # This is an activation event, triggering it will cause the package to be
@@ -30,5 +30,5 @@ describe "RubyTest", ->
         activationPromise
 
       runs ->
-        atom.packages.activatePackage('platformio-ide-terminal').then ->
+        atom.packages.activatePackage('terminus').then ->
           expect(RubyTestView.prototype.initialize).toHaveBeenCalled()


### PR DESCRIPTION
As platform-ide-terminal is no longer maintained and has broken down recently. I know this package is also no longer maintained, but this PR might help others too.

To install from repo:

* Uninstall original ruby-test package from atom
* `git clone https://github.com/moiristo/atom-ruby-test.git`
* Run `apm link` from package root dir

