### PR TITLE
Launch current minitest case when its name contains spaces

### DIFF
--- a/lib/source-info.coffee
+++ b/lib/source-info.coffee
@@ -46,7 +46,7 @@ module.exports =
       regExp = @regExpForTestStyle[testStyle]
       match = testHeaderLine? and testHeaderLine.match(regExp) or null
       if match
-        match[1]
+        match[1].replace(/ /g,'_')
       else
         ""
 


### PR DESCRIPTION
In a Minitest case, the action "Test Single" (ruby-test:test-single) does not work when the test-case name has spaces.
This is because:
`test "my awesome feature" do`
is equivalent to:
`def test_my_awesome_feature`

The triggered command is:
`ruby -I test test/unit/contact_import_test.rb -n "/my awesome feature/"`
But should be:
`ruby -I test test/unit/contact_import_test.rb -n "/my_awesome_feature/"`

This one-line patch simply replaces spaces with "_" on the fly, to make it work.
I'm not sure it will work for everybody, but hopefully some might find it useful.